### PR TITLE
feat: Network Engine (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ Minimal neural network library in Go. Inspired by [aspirina](https://github.com/
 pkg/model/     Neural network numerical model (weights, activations, gradients)
 pkg/calc/      Math primitives
 pkg/validate/  Input validation (primitive types only, no model dependency)
+pkg/layer/     Composable neural network layer (weights + activation + cache)
+pkg/network/   Feedforward MLP with backpropagation training
+pkg/random/    Random matrix initialization for weight seeding
 main.go        API smoke test
 ```
 
@@ -37,6 +40,7 @@ Always use `make`, never raw `go` commands directly.
 - Table-driven tests, 100% coverage on math packages
 - Panic only for programmer errors (dimension mismatch)
 - Always use `make` targets, never raw `go` commands
+- Subpackage constructors follow `pkg/layer.New()`, `pkg/network.New()`, `pkg/random.New()` pattern. No `NewLayer`, `NewNetwork`, etc.
 
 ## Roadmap
 See [ROADMAP.md](ROADMAP.md)

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ build:
 	go build -o dipirona .
 
 bench:
-	go test ./pkg/model ./pkg/model/layer -bench=. -benchtime=1s
+	go test ./pkg/model ./pkg/model/layer ./pkg/network -bench=. -benchtime=1s

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ A composable neural network layer. Decoupled from any specific task.
 
 **Value:** Building block for any feedforward architecture. Not locked to XOR.
 
-## Phase 3: Network Engine
+## Phase 3: Network Engine ✅
 Feedforward MLP with backpropagation training.
 
 - `Network`: ordered list of Layers, predict, train

--- a/main.go
+++ b/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"math"
 
 	"dipirona/pkg/calc"
 	"dipirona/pkg/model"
 	"dipirona/pkg/model/layer"
+	"dipirona/pkg/network"
+	"dipirona/pkg/random"
 )
 
 func main() {
@@ -25,6 +28,8 @@ func main() {
 	fmt.Println("A^T:", a.Transpose())
 	fmt.Println("A * B:", a.Multiply(b))
 	fmt.Println("A * 2:", a.Map(func(x float64) float64 { return x * 2 }))
+	fmt.Println("A - A/2:", a.Subtract(a.Map(func(x float64) float64 { return x / 2 })))
+	fmt.Println("A * 0.5:", a.Scale(0.5))
 
 	// Activation functions
 	fmt.Printf("Sigmoid(0) = %v\n", calc.Sigmoid(0))
@@ -32,14 +37,18 @@ func main() {
 	fmt.Printf("Relu(2.5) = %v\n", calc.Relu(2.5))
 	fmt.Printf("Relu(-1.0) = %v\n", calc.Relu(-1.0))
 
+	// MSE
+	predicted := []float64{0.8, 0.2, 0.6}
+	target := []float64{1.0, 0.0, 0.5}
+	fmt.Printf("MSE = %v\n", calc.MSE(predicted, target))
+	fmt.Printf("MSEDerivative = %v\n", calc.MSEDerivative(predicted, target))
+
 	// Layer — forward pass with different activations
 	weights := model.New([][]float64{
 		{0.5, -0.2},
 		{0.1, 0.8},
 	})
-	input := model.New([][]float64{
-		{1.0, 1.0},
-	})
+	input := model.New([][]float64{{1.0, 1.0}})
 
 	lNone := layer.New(weights, model.ActivationNone)
 	outputNone := lNone.Forward(input)
@@ -52,4 +61,50 @@ func main() {
 	lReLU := layer.New(weights, model.ActivationReLU)
 	outputReLU := lReLU.Forward(input)
 	fmt.Println("Layer (ReLU):", outputReLU)
+
+	// Activation derivative
+	z := model.New([][]float64{{0.0, 1.0, -1.0}})
+	fmt.Println("Sigmoid derivative:", model.ActivationSigmoid.ApplyDerivative(z))
+	fmt.Println("ReLU derivative:", model.ActivationReLU.ApplyDerivative(z))
+	fmt.Println("None derivative:", model.ActivationNone.ApplyDerivative(z))
+
+	// Layer backward pass
+	delta := model.New([][]float64{{0.1, -0.3}})
+	grad := lNone.Backward(delta, 0.5)
+	fmt.Println("Gradient for previous layer:", grad)
+	fmt.Println("Updated weights:", lNone.Weights())
+
+	// Random weight initialization
+	randWeights := random.New(2, 3)
+	fmt.Println("Random weights (2x3):", randWeights)
+	randSeeded := random.NewWithSeed(2, 3, 42)
+	fmt.Println("Seeded random (2x3, seed=42):", randSeeded)
+
+	// XOR training with MLP
+	fmt.Println("\n--- XOR Training ---")
+
+	w1 := random.NewWithSeed(2, 2, 1)
+	w2 := random.NewWithSeed(2, 1, 101)
+	hidden := layer.New(w1, model.ActivationSigmoid)
+	output := layer.New(w2, model.ActivationSigmoid)
+	mlp := network.New([]layer.Layer{hidden, output}, network.WithLearningRate(5.0))
+
+	batchInput := model.New([][]float64{{0, 0}, {0, 1}, {1, 0}, {1, 1}})
+	batchTarget := model.New([][]float64{{0}, {1}, {1}, {0}})
+
+	xorInputs := [][][]float64{{{0, 0}}, {{0, 1}}, {{1, 0}}, {{1, 1}}}
+	xorTargets := []float64{0, 1, 1, 0}
+
+	// Train
+	for epoch := 0; epoch < 10000; epoch++ {
+		mlp.Train(batchInput, batchTarget)
+	}
+
+	// Verify
+	fmt.Println("Results after 10000 epochs:")
+	for i := 0; i < 4; i++ {
+		pred := mlp.Predict(model.New(xorInputs[i]))
+		fmt.Printf("  XOR %v = %.4f (expected %.1f, diff %.4f)\n",
+			xorInputs[i][0], pred.At(0, 0), xorTargets[i], math.Abs(pred.At(0, 0)-xorTargets[i]))
+	}
 }

--- a/pkg/calc/mse.go
+++ b/pkg/calc/mse.go
@@ -1,0 +1,24 @@
+package calc
+
+// MSE returns the mean squared error between predicted and target values.
+func MSE(predicted, target []float64) float64 {
+	n := len(predicted)
+	var sum float64
+	for i := 0; i < n; i++ {
+		diff := predicted[i] - target[i]
+		sum += diff * diff
+	}
+	return sum / float64(n)
+}
+
+// MSEDerivative returns the per-element derivative of MSE with respect to predicted values.
+// derivative_i = 2 * (predicted_i - target_i) / n
+func MSEDerivative(predicted, target []float64) []float64 {
+	n := len(predicted)
+	n64 := float64(n)
+	result := make([]float64, n)
+	for i := 0; i < n; i++ {
+		result[i] = 2 * (predicted[i] - target[i]) / n64
+	}
+	return result
+}

--- a/pkg/calc/mse_test.go
+++ b/pkg/calc/mse_test.go
@@ -1,0 +1,57 @@
+package calc
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMSE_ReturnsMeanSquaredError(t *testing.T) {
+	predicted := []float64{0.8, 0.2, 0.6}
+	target := []float64{1.0, 0.0, 0.5}
+
+	// MSE = ((0.8-1.0)² + (0.2-0.0)² + (0.6-0.5)²) / 3
+	//     = (0.04 + 0.04 + 0.01) / 3
+	//     = 0.09 / 3
+	//     = 0.03
+	got := MSE(predicted, target)
+	want := 0.03
+	if math.Abs(got-want) > 1e-10 {
+		t.Errorf("expected MSE = %v, got %v", want, got)
+	}
+}
+
+func TestMSE_PerfectPredictionReturnsZero(t *testing.T) {
+	predicted := []float64{1.0, 0.0, 0.5}
+	target := []float64{1.0, 0.0, 0.5}
+
+	got := MSE(predicted, target)
+	if got != 0.0 {
+		t.Errorf("expected MSE = 0.0 for perfect prediction, got %v", got)
+	}
+}
+
+func TestMSEDerivative_ReturnsPerElementDerivative(t *testing.T) {
+	predicted := []float64{0.8, 0.2}
+	target := []float64{1.0, 0.0}
+	// derivative = 2*(predicted - target) / n
+	// [2*(0.8-1.0)/2, 2*(0.2-0.0)/2] = [-0.2, 0.2]
+	got := MSEDerivative(predicted, target)
+	want := []float64{-0.2, 0.2}
+	for i := range got {
+		if math.Abs(got[i]-want[i]) > 1e-10 {
+			t.Errorf("expected MSEDerivative[%d] = %v, got %v", i, want[i], got[i])
+		}
+	}
+}
+
+func TestMSEDerivative_ZeroDifferenceReturnsZero(t *testing.T) {
+	predicted := []float64{0.5, 0.5}
+	target := []float64{0.5, 0.5}
+
+	got := MSEDerivative(predicted, target)
+	for i, v := range got {
+		if v != 0.0 {
+			t.Errorf("expected MSEDerivative[%d] = 0.0 for zero difference, got %v", i, v)
+		}
+	}
+}

--- a/pkg/model/activation.go
+++ b/pkg/model/activation.go
@@ -11,6 +11,22 @@ const (
 	ActivationReLU                      // Rectified linear unit
 )
 
+// ApplyDerivative returns the result of applying the activation's derivative element-wise.
+// For ActivationNone, returns a matrix of ones (derivative of identity).
+// For ActivationSigmoid and ActivationReLU, applies the derivative to the pre-activation values.
+func (a Activation) ApplyDerivative(m Matrix) Matrix {
+	switch a {
+	case ActivationNone:
+		return m.Map(func(float64) float64 { return 1.0 })
+	case ActivationSigmoid:
+		return m.Map(calc.SigmoidDerivative)
+	case ActivationReLU:
+		return m.Map(calc.ReluDerivative)
+	default:
+		panic("unknown activation function")
+	}
+}
+
 // Apply returns the result of applying the activation function element-wise.
 // For ActivationNone, returns the input unchanged.
 func (a Activation) Apply(m Matrix) Matrix {

--- a/pkg/model/activation_test.go
+++ b/pkg/model/activation_test.go
@@ -34,6 +34,72 @@ func TestActivationSigmoid_ApplyAppliesSigmoid(t *testing.T) {
 	}
 }
 
+func TestActivationNone_ApplyDerivativeReturnsUnchanged(t *testing.T) {
+	m := New([][]float64{
+		{1.0, -2.0},
+		{3.0, -4.0},
+	})
+
+	result := ActivationNone.ApplyDerivative(m)
+
+	if result.At(0, 0) != 1.0 || result.At(0, 1) != 1.0 || result.At(1, 0) != 1.0 || result.At(1, 1) != 1.0 {
+		t.Errorf("expected all ones for None derivative, got %v", result)
+	}
+}
+
+func TestActivationSigmoid_ApplyDerivativeAppliesSigmoidDerivative(t *testing.T) {
+	m := New([][]float64{
+		{0.0, 1.0},
+	})
+
+	result := ActivationSigmoid.ApplyDerivative(m)
+
+	if math.Abs(result.At(0, 0)-calc.SigmoidDerivative(0.0)) > 1e-10 {
+		t.Errorf("expected SigmoidDerivative(0.0) = %v, got %v", calc.SigmoidDerivative(0.0), result.At(0, 0))
+	}
+	if math.Abs(result.At(0, 1)-calc.SigmoidDerivative(1.0)) > 1e-10 {
+		t.Errorf("expected SigmoidDerivative(1.0) = %v, got %v", calc.SigmoidDerivative(1.0), result.At(0, 1))
+	}
+}
+
+func TestActivationReLU_ApplyDerivativeAppliesReluDerivative(t *testing.T) {
+	m := New([][]float64{
+		{2.5, -1.0},
+		{0.0, 3.0},
+	})
+
+	result := ActivationReLU.ApplyDerivative(m)
+
+	expected := [][]float64{
+		{1.0, 0.0},
+		{0.0, 1.0},
+	}
+	for r := 0; r < 2; r++ {
+		for c := 0; c < 2; c++ {
+			if result.At(r, c) != expected[r][c] {
+				t.Errorf("expected At(%d,%d) = %v, got %v", r, c, expected[r][c], result.At(r, c))
+			}
+		}
+	}
+}
+
+func TestApplyDerivative_UnknownActivationPanics(t *testing.T) {
+	m := New([][]float64{{1.0}})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic for unknown activation")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "unknown activation function" {
+			t.Errorf("expected 'unknown activation function', got %v", r)
+		}
+	}()
+
+	Activation(99).ApplyDerivative(m)
+}
+
 func TestApply_UnknownActivationPanics(t *testing.T) {
 	m := New([][]float64{{1.0}})
 

--- a/pkg/model/layer/layer.go
+++ b/pkg/model/layer/layer.go
@@ -5,11 +5,13 @@ import (
 	"dipirona/pkg/model"
 )
 
-// Layer represents a single neural network layer with weights, activation, and cached output.
+// Layer represents a single neural network layer with weights, activation, and cached state.
 type Layer struct {
 	weights    model.Matrix
 	activation model.Activation
-	output     *model.Matrix
+	input      *model.Matrix
+	z          *model.Matrix // pre-activation: input * weights
+	output     *model.Matrix // post-activation: activation(z)
 }
 
 // New creates a Layer with the given weights and activation function.
@@ -26,12 +28,33 @@ func (l Layer) Weights() model.Matrix {
 }
 
 // Forward computes the output of the layer for the given input.
-// It multiplies input by weights and applies the activation function.
+// It multiplies input by weights, caches input and pre-activation for backpropagation,
+// and applies the activation function.
 func (l *Layer) Forward(input model.Matrix) model.Matrix {
-	result := input.Multiply(l.weights)
-	applied := l.activation.Apply(result)
+	l.input = &input
+	z := input.Multiply(l.weights)
+	l.z = &z
+	applied := l.activation.Apply(z)
 	l.output = &applied
 	return applied
+}
+
+// PreActivation returns the cached pre-activation (z) from the last Forward call.
+// Panics if Forward has not been called yet.
+func (l Layer) PreActivation() model.Matrix {
+	if l.z == nil {
+		panic("pre-activation not available: call Forward first")
+	}
+	return *l.z
+}
+
+// Input returns the cached input from the last Forward call.
+// Panics if Forward has not been called yet.
+func (l Layer) Input() model.Matrix {
+	if l.input == nil {
+		panic("input not available: call Forward first")
+	}
+	return *l.input
 }
 
 // Output returns the cached output from the last Forward call.
@@ -41,4 +64,31 @@ func (l Layer) Output() model.Matrix {
 		panic("output not available: call Forward first")
 	}
 	return *l.output
+}
+
+// Backward propagates the gradient backward through the layer, updates weights,
+// and returns the gradient for the previous layer.
+// delta is the gradient from the next layer (or loss derivative for the output layer).
+// lr is the learning rate for weight updates.
+// Panics if Forward has not been called yet.
+func (l *Layer) Backward(delta model.Matrix, lr float64) model.Matrix {
+	if l.z == nil || l.input == nil {
+		panic("backward not available: call Forward first")
+	}
+
+	// Apply activation derivative to get local delta
+	localDelta := l.activation.ApplyDerivative(*l.z).Zip(delta, func(a, b float64) float64 {
+		return a * b
+	})
+
+	// dW = input.T * localDelta
+	dW := l.input.Transpose().Multiply(localDelta)
+
+	// Gradient for previous layer: localDelta * weights.T (before update)
+	grad := localDelta.Multiply(l.weights.Transpose())
+
+	// Update weights: W = W - lr * dW
+	l.weights = l.weights.Subtract(dW.Scale(lr))
+
+	return grad
 }

--- a/pkg/model/layer/layer_backward_test.go
+++ b/pkg/model/layer/layer_backward_test.go
@@ -1,0 +1,186 @@
+package layer
+
+import (
+	"dipirona/pkg/calc"
+	"dipirona/pkg/model"
+	"math"
+	"testing"
+)
+
+func TestForward_CachesInputAndPreActivation(t *testing.T) {
+	w := model.New([][]float64{
+		{0.5, -0.2},
+		{0.1, 0.8},
+	})
+	l := New(w, model.ActivationNone)
+
+	input := model.New([][]float64{
+		{1.0, 1.0},
+	})
+
+	l.Forward(input)
+
+	// Pre-activation (z) = input * weights = [0.6, 0.6]
+	z := l.PreActivation()
+	if z.Rows != 1 || z.Cols != 2 {
+		t.Fatalf("expected z dimensions 1x2, got %dx%d", z.Rows, z.Cols)
+	}
+	if math.Abs(z.At(0, 0)-0.6) > 1e-10 {
+		t.Errorf("expected z.At(0,0) = 0.6, got %v", z.At(0, 0))
+	}
+
+	// Cached input
+	cachedInput := l.Input()
+	if cachedInput.Rows != 1 || cachedInput.Cols != 2 {
+		t.Fatalf("expected input dimensions 1x2, got %dx%d", cachedInput.Rows, cachedInput.Cols)
+	}
+	if cachedInput.At(0, 0) != 1.0 || cachedInput.At(0, 1) != 1.0 {
+		t.Errorf("expected cached input [1.0, 1.0], got %v", cachedInput)
+	}
+}
+
+func TestPreActivation_BeforeForwardPanics(t *testing.T) {
+	w := model.New([][]float64{{1.0, 2.0}, {3.0, 4.0}})
+	l := New(w, model.ActivationNone)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic when calling PreActivation before Forward")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "pre-activation not available: call Forward first" {
+			t.Errorf("expected panic message 'pre-activation not available: call Forward first', got %v", r)
+		}
+	}()
+
+	l.PreActivation()
+}
+
+func TestInput_BeforeForwardPanics(t *testing.T) {
+	w := model.New([][]float64{{1.0, 2.0}, {3.0, 4.0}})
+	l := New(w, model.ActivationNone)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic when calling Input before Forward")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "input not available: call Forward first" {
+			t.Errorf("expected panic message 'input not available: call Forward first', got %v", r)
+		}
+	}()
+
+	l.Input()
+}
+
+func TestBackward_UpdatesWeightsAndReturnsGradient(t *testing.T) {
+	// Layer with None activation so we can compute exact values
+	// weights: [[0.5, -0.2], [0.1, 0.8]] (2x2)
+	// input: [[1.0, 1.0]] (1x2)
+	// z = input * weights = [0.6, 0.6] (1x2)  — pre-activation
+	// output = z since activation is None
+	w := model.New([][]float64{
+		{0.5, -0.2},
+		{0.1, 0.8},
+	})
+	l := New(w, model.ActivationNone)
+
+	input := model.New([][]float64{
+		{1.0, 1.0},
+	})
+	l.Forward(input)
+
+	// output delta: [[0.1, -0.3]] (1x2)
+	delta := model.New([][]float64{
+		{0.1, -0.3},
+	})
+
+	lr := 0.5
+	grad := l.Backward(delta, lr)
+
+	// For None activation: derivative = 1, so delta passes through
+	// dW = input.T * delta = [[1], [1]] * [[0.1, -0.3]] = [[0.1, -0.3], [0.1, -0.3]] (2x2)
+	// new weights = W - lr * dW = [[0.5-0.05, -0.2+0.15], [0.1-0.05, 0.8+0.15]]
+	//             = [[0.45, -0.05], [0.05, 0.95]]
+
+	newWeights := l.Weights()
+	if math.Abs(newWeights.At(0, 0)-0.45) > 1e-10 {
+		t.Errorf("expected new W(0,0) = 0.45, got %v", newWeights.At(0, 0))
+	}
+	if math.Abs(newWeights.At(0, 1)-(-0.05)) > 1e-10 {
+		t.Errorf("expected new W(0,1) = -0.05, got %v", newWeights.At(0, 1))
+	}
+	if math.Abs(newWeights.At(1, 0)-0.05) > 1e-10 {
+		t.Errorf("expected new W(1,0) = 0.05, got %v", newWeights.At(1, 0))
+	}
+	if math.Abs(newWeights.At(1, 1)-0.95) > 1e-10 {
+		t.Errorf("expected new W(1,1) = 0.95, got %v", newWeights.At(1, 1))
+	}
+
+	// grad for previous layer = delta * weights.T
+	// delta (1x2) * weights.T (2x2) = [0.1*0.5+(-0.3)*(-0.2), 0.1*0.1+(-0.3)*0.8]
+	//                               = [0.05+0.06, 0.01-0.24] = [0.11, -0.23]
+	if math.Abs(grad.At(0, 0)-0.11) > 1e-10 {
+		t.Errorf("expected grad.At(0,0) = 0.11, got %v", grad.At(0, 0))
+	}
+	if math.Abs(grad.At(0, 1)-(-0.23)) > 1e-10 {
+		t.Errorf("expected grad.At(0,1) = -0.23, got %v", grad.At(0, 1))
+	}
+}
+
+func TestBackward_WithSigmoidActivation(t *testing.T) {
+	// weights: [[0.5]] (1x1), activation: Sigmoid
+	// input: [[0.5]] (1x1)
+	// z = 0.5 * 0.5 = 0.25, output = sigmoid(0.25) ≈ 0.56218
+	w := model.New([][]float64{{0.5}})
+	l := New(w, model.ActivationSigmoid)
+
+	input := model.New([][]float64{{0.5}})
+	l.Forward(input)
+
+	// delta from next layer: [[1.0]]
+	delta := model.New([][]float64{{1.0}})
+
+	lr := 1.0
+	grad := l.Backward(delta, lr)
+
+	z := l.PreActivation()
+	sigDeriv := calc.SigmoidDerivative(z.At(0, 0))
+
+	// local_delta = delta * sigmoid'(z) = 1.0 * sigDeriv
+	// dW = input.T * local_delta = [[0.5]] * [[sigDeriv]] = [[0.5*sigDeriv]]
+	// new weight = 0.5 - 1.0 * 0.5*sigDeriv
+	expectedNewW := 0.5 - 1.0*0.5*sigDeriv
+	newW := l.Weights()
+	if math.Abs(newW.At(0, 0)-expectedNewW) > 1e-10 {
+		t.Errorf("expected new W(0,0) = %v, got %v", expectedNewW, newW.At(0, 0))
+	}
+
+	// grad = local_delta * weights.T = sigDeriv * 0.5
+	expectedGrad := sigDeriv * 0.5
+	if math.Abs(grad.At(0, 0)-expectedGrad) > 1e-10 {
+		t.Errorf("expected grad.At(0,0) = %v, got %v", expectedGrad, grad.At(0, 0))
+	}
+}
+
+func TestBackward_BeforeForwardPanics(t *testing.T) {
+	w := model.New([][]float64{{1.0, 2.0}, {3.0, 4.0}})
+	l := New(w, model.ActivationNone)
+
+	delta := model.New([][]float64{{1.0, 1.0}})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic when calling Backward before Forward")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "backward not available: call Forward first" {
+			t.Errorf("expected panic message 'backward not available: call Forward first', got %v", r)
+		}
+	}()
+
+	l.Backward(delta, 1.0)
+}

--- a/pkg/model/matrix.go
+++ b/pkg/model/matrix.go
@@ -125,6 +125,17 @@ func (m Matrix) Map(fn func(float64) float64) Matrix {
 	}
 }
 
+// Subtract returns a new Matrix where each element is the result of subtracting
+// the corresponding element of other from m.
+func (m Matrix) Subtract(other Matrix) Matrix {
+	return m.Zip(other, func(a, b float64) float64 { return a - b })
+}
+
+// Scale returns a new Matrix where each element is multiplied by the given scalar.
+func (m Matrix) Scale(s float64) Matrix {
+	return m.Map(func(x float64) float64 { return x * s })
+}
+
 // String returns a human-readable representation of the matrix.
 func (m Matrix) String() string {
 	var b strings.Builder

--- a/pkg/model/matrix_test.go
+++ b/pkg/model/matrix_test.go
@@ -172,6 +172,49 @@ func TestMap_AppliesScalarFunction(t *testing.T) {
 	}
 }
 
+func TestSubtract_SubtractsCorrespondingElements(t *testing.T) {
+	a := New([][]float64{
+		{10, 20},
+		{30, 40},
+	})
+	b := New([][]float64{
+		{1, 2},
+		{3, 4},
+	})
+
+	result := a.Subtract(b)
+
+	if result.At(0, 0) != 9 || result.At(0, 1) != 18 || result.At(1, 0) != 27 || result.At(1, 1) != 36 {
+		t.Errorf("expected element-wise subtraction, got %v", result)
+	}
+}
+
+func TestSubtract_IncompatibleDimensionsPanics(t *testing.T) {
+	a := New([][]float64{{1, 2}})
+	b := New([][]float64{{1, 2, 3}})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for incompatible dimensions")
+		}
+	}()
+
+	a.Subtract(b)
+}
+
+func TestScale_MultipliesAllElementsByScalar(t *testing.T) {
+	m := New([][]float64{
+		{1, 2},
+		{3, 4},
+	})
+
+	result := m.Scale(0.5)
+
+	if result.At(0, 0) != 0.5 || result.At(0, 1) != 1.0 || result.At(1, 0) != 1.5 || result.At(1, 1) != 2.0 {
+		t.Errorf("expected scaled matrix, got %v", result)
+	}
+}
+
 func TestString_ReturnsReadableFormat(t *testing.T) {
 	m := New([][]float64{
 		{1, 2},

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -1,0 +1,108 @@
+// Package network provides a feedforward MLP with backpropagation training.
+package network
+
+import (
+	"dipirona/pkg/calc"
+	"dipirona/pkg/model"
+	"dipirona/pkg/model/layer"
+)
+
+// MLP represents a multi-layer perceptron.
+type MLP struct {
+	layers       []layer.Layer
+	learningRate float64
+}
+
+// Option configures an MLP during construction.
+type Option func(*MLP)
+
+// WithLearningRate sets the learning rate for training. Default is 1.0.
+func WithLearningRate(lr float64) Option {
+	return func(m *MLP) {
+		m.learningRate = lr
+	}
+}
+
+// New creates an MLP with the given layers and options.
+// Panics if the layer list is empty.
+func New(layers []layer.Layer, opts ...Option) MLP {
+	if len(layers) == 0 {
+		panic("network: at least one layer is required")
+	}
+
+	m := MLP{
+		layers:       layers,
+		learningRate: 1.0,
+	}
+
+	for _, opt := range opts {
+		opt(&m)
+	}
+
+	return m
+}
+
+// Layers returns the MLP's layers.
+func (m MLP) Layers() []layer.Layer {
+	return m.layers
+}
+
+// LearningRate returns the MLP's learning rate.
+func (m MLP) LearningRate() float64 {
+	return m.learningRate
+}
+
+// Predict chains Forward across all layers and returns the final output.
+func (m MLP) Predict(input model.Matrix) model.Matrix {
+	output := input
+	for i := range m.layers {
+		output = m.layers[i].Forward(output)
+	}
+	return output
+}
+
+// Train runs one forward pass, computes MSE loss, backpropagates gradients,
+// updates weights, and returns the loss value.
+func (m *MLP) Train(input, target model.Matrix) float64 {
+	// Forward pass
+	output := m.Predict(input)
+
+	// Compute MSE loss
+	predicted := flatten(output)
+	targets := flatten(target)
+	loss := calc.MSE(predicted, targets)
+
+	// Compute output delta: MSE derivative element-wise * activation derivative
+	lossDeriv := calc.MSEDerivative(predicted, targets)
+	delta := model.New(unflatten(lossDeriv, output.Rows, output.Cols))
+
+	// Backward pass (reverse order)
+	for i := len(m.layers) - 1; i >= 0; i-- {
+		delta = m.layers[i].Backward(delta, m.learningRate)
+	}
+
+	return loss
+}
+
+// flatten converts a Matrix to a []float64 in row-major order.
+func flatten(m model.Matrix) []float64 {
+	result := make([]float64, m.Rows*m.Cols)
+	for r := 0; r < m.Rows; r++ {
+		for c := 0; c < m.Cols; c++ {
+			result[r*m.Cols+c] = m.At(r, c)
+		}
+	}
+	return result
+}
+
+// unflatten converts a []float64 to a 2D slice with the given dimensions.
+func unflatten(data []float64, rows, cols int) [][]float64 {
+	result := make([][]float64, rows)
+	for r := 0; r < rows; r++ {
+		result[r] = make([]float64, cols)
+		for c := 0; c < cols; c++ {
+			result[r][c] = data[r*cols+c]
+		}
+	}
+	return result
+}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -1,0 +1,108 @@
+package network
+
+import (
+	"dipirona/pkg/model"
+	"dipirona/pkg/model/layer"
+	"math"
+	"testing"
+)
+
+// --- network.New tests ---
+
+func TestNew_CreatesMLPWithLayersAndDefaultLearningRate(t *testing.T) {
+	l1 := layer.New(model.New([][]float64{{0.5, -0.2}, {0.1, 0.8}}), model.ActivationSigmoid)
+	l2 := layer.New(model.New([][]float64{{0.4}, {0.3}}), model.ActivationSigmoid)
+
+	mlp := New([]layer.Layer{l1, l2})
+
+	if mlp.LearningRate() != 1.0 {
+		t.Errorf("expected default learning rate 1.0, got %v", mlp.LearningRate())
+	}
+	if len(mlp.Layers()) != 2 {
+		t.Errorf("expected 2 layers, got %d", len(mlp.Layers()))
+	}
+}
+
+func TestNew_WithLearningRateOption(t *testing.T) {
+	l1 := layer.New(model.New([][]float64{{0.5, -0.2}, {0.1, 0.8}}), model.ActivationSigmoid)
+
+	mlp := New([]layer.Layer{l1}, WithLearningRate(0.5))
+
+	if mlp.LearningRate() != 0.5 {
+		t.Errorf("expected learning rate 0.5, got %v", mlp.LearningRate())
+	}
+}
+
+func TestNew_EmptyLayerListPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic for empty layer list")
+		}
+		msg, ok := r.(string)
+		if !ok || msg == "" {
+			t.Errorf("expected non-empty panic message, got %v", r)
+		}
+	}()
+
+	New([]layer.Layer{})
+}
+
+// --- Predict tests ---
+
+func TestPredict_ChainsForwardAcrossLayers(t *testing.T) {
+	// 2 layers: input(1x2) -> hidden(2x2, Sigmoid) -> output(2x1, Sigmoid)
+	l1 := layer.New(model.New([][]float64{
+		{0.5, -0.2},
+		{0.1, 0.8},
+	}), model.ActivationSigmoid)
+	l2 := layer.New(model.New([][]float64{
+		{0.4},
+		{0.3},
+	}), model.ActivationSigmoid)
+
+	mlp := New([]layer.Layer{l1, l2})
+
+	input := model.New([][]float64{{1.0, 1.0}})
+	output := mlp.Predict(input)
+
+	if output.Rows != 1 || output.Cols != 1 {
+		t.Fatalf("expected 1x1 output, got %dx%d", output.Rows, output.Cols)
+	}
+
+	// Manual calculation:
+	// hidden = sigmoid([1.0, 1.0] * [[0.5, -0.2], [0.1, 0.8]])
+	//       = sigmoid([0.6, 0.6])
+	//       = [sigmoid(0.6), sigmoid(0.6)]
+	sig06 := 1.0 / (1.0 + math.Exp(-0.6))
+	// output = sigmoid([sig06, sig06] * [[0.4], [0.3]])
+	//        = sigmoid(sig06*0.4 + sig06*0.3)
+	//        = sigmoid(sig06 * 0.7)
+	preOut := sig06 * 0.7
+	expected := 1.0 / (1.0+math.Exp(-preOut))
+
+	if math.Abs(output.At(0, 0)-expected) > 1e-10 {
+		t.Errorf("expected output %v, got %v", expected, output.At(0, 0))
+	}
+}
+
+func TestPredict_WrongDimensionInputPanics(t *testing.T) {
+	// Hidden layer expects 2 inputs (2 rows in weights)
+	l1 := layer.New(model.New([][]float64{
+		{0.5, -0.2},
+		{0.1, 0.8},
+	}), model.ActivationSigmoid)
+
+	mlp := New([]layer.Layer{l1})
+
+	// Input has 3 columns but layer expects 2
+	input := model.New([][]float64{{1.0, 1.0, 1.0}})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for dimension mismatch")
+		}
+	}()
+
+	mlp.Predict(input)
+}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"dipirona/pkg/model"
 	"dipirona/pkg/model/layer"
+	"dipirona/pkg/random"
 	"math"
 	"testing"
 )
@@ -105,4 +106,96 @@ func TestPredict_WrongDimensionInputPanics(t *testing.T) {
 	}()
 
 	mlp.Predict(input)
+}
+
+// --- Train tests ---
+
+func TestTrain_SingleEpochReturnsLoss(t *testing.T) {
+	// Simple 1-layer network
+	l1 := layer.New(model.New([][]float64{{0.5}, {0.3}}), model.ActivationSigmoid)
+	mlp := New([]layer.Layer{l1}, WithLearningRate(0.5))
+
+	input := model.New([][]float64{{1.0, 1.0}})
+	target := model.New([][]float64{{1.0}})
+
+	loss := mlp.Train(input, target)
+
+	if loss < 0 {
+		t.Errorf("expected non-negative loss, got %v", loss)
+	}
+}
+
+func TestTrain_LossDecreasesOverEpochs(t *testing.T) {
+	// 2-layer network
+	l1 := layer.New(model.New([][]float64{
+		{0.5, -0.2},
+		{0.1, 0.8},
+	}), model.ActivationSigmoid)
+	l2 := layer.New(model.New([][]float64{
+		{0.4},
+		{0.3},
+	}), model.ActivationSigmoid)
+	mlp := New([]layer.Layer{l1, l2}, WithLearningRate(0.5))
+
+	input := model.New([][]float64{{1.0, 1.0}})
+	target := model.New([][]float64{{1.0}})
+
+	firstLoss := mlp.Train(input, target)
+
+	// Train a few more times, loss should decrease
+	var lastLoss float64 = firstLoss
+	for i := 0; i < 10; i++ {
+		loss := mlp.Train(input, target)
+		if loss > lastLoss+1e-10 {
+			// Loss may not always decrease on every single step due to the simplicity of the test,
+			// but the general trend should be downward.
+			// We don't make a hard assertion here for a single step.
+		}
+		lastLoss = loss
+	}
+
+	// After several epochs, loss should be meaningfully less than first loss
+	if lastLoss >= firstLoss {
+		t.Errorf("expected loss to decrease over training: first=%v, last=%v", firstLoss, lastLoss)
+	}
+}
+
+func TestTrain_XORConvergence(t *testing.T) {
+	// The canonical integration test: train a 2->2->1 MLP on XOR
+	// to convergence (all outputs within 0.1 of targets within 10000 epochs).
+	// Uses batch training (all 4 patterns per epoch) for stable convergence.
+
+	// Network: 2 inputs -> 2 hidden (Sigmoid) -> 1 output (Sigmoid)
+	w1 := random.NewWithSeed(2, 2, 1)
+	w2 := random.NewWithSeed(2, 1, 101)
+
+	l1 := layer.New(w1, model.ActivationSigmoid)
+	l2 := layer.New(w2, model.ActivationSigmoid)
+
+	mlp := New([]layer.Layer{l1, l2}, WithLearningRate(5.0))
+
+	// Batch XOR training: all 4 patterns as a single matrix per epoch
+	batchInput := model.New([][]float64{{0, 0}, {0, 1}, {1, 0}, {1, 1}})
+	batchTarget := model.New([][]float64{{0}, {1}, {1}, {0}})
+
+	maxEpochs := 10000
+	tolerance := 0.1
+
+	for epoch := 0; epoch < maxEpochs; epoch++ {
+		mlp.Train(batchInput, batchTarget)
+	}
+
+	// Verify convergence on each pattern individually
+	xorInputs := [][][]float64{{{0, 0}}, {{0, 1}}, {{1, 0}}, {{1, 1}}}
+	xorTargets := []float64{0, 1, 1, 0}
+
+	for i := 0; i < 4; i++ {
+		predicted := mlp.Predict(model.New(xorInputs[i]))
+		target := xorTargets[i]
+		pred := predicted.At(0, 0)
+		if math.Abs(pred-target) > tolerance {
+			t.Errorf("XOR not converged after %d epochs: input=%v, target=%.1f, got=%.6f",
+					maxEpochs, xorInputs[i], target, pred)
+		}
+	}
 }

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,0 +1,27 @@
+// Package random provides random matrix initialization for weight seeding.
+package random
+
+import (
+	"dipirona/pkg/model"
+	"math/rand"
+)
+
+// New creates a Matrix of the given dimensions with values sampled uniformly from (-0.5, 0.5).
+// Uses a package-level default seed for reproducibility within a single run.
+func New(rows, cols int) model.Matrix {
+	return NewWithSeed(rows, cols, 42)
+}
+
+// NewWithSeed creates a Matrix of the given dimensions with values sampled uniformly from (-0.5, 0.5),
+// using the provided seed for deterministic results.
+func NewWithSeed(rows, cols int, seed int64) model.Matrix {
+	r := rand.New(rand.NewSource(seed))
+	data := make([][]float64, rows)
+	for i := 0; i < rows; i++ {
+		data[i] = make([]float64, cols)
+		for j := 0; j < cols; j++ {
+			data[i][j] = r.Float64() - 0.5
+		}
+	}
+	return model.New(data)
+}

--- a/pkg/random/random_test.go
+++ b/pkg/random/random_test.go
@@ -1,0 +1,77 @@
+package random
+
+import (
+	"testing"
+)
+
+func TestNew_CorrectDimensions(t *testing.T) {
+	m := New(3, 4)
+
+	if m.Rows != 3 {
+		t.Errorf("expected Rows = 3, got %d", m.Rows)
+	}
+	if m.Cols != 4 {
+		t.Errorf("expected Cols = 4, got %d", m.Cols)
+	}
+}
+
+func TestNew_ValuesInRange(t *testing.T) {
+	m := New(100, 100)
+
+	for r := 0; r < m.Rows; r++ {
+		for c := 0; c < m.Cols; c++ {
+			v := m.At(r, c)
+			if v <= -0.5 || v >= 0.5 {
+				t.Errorf("value at (%d,%d) = %v, expected in (-0.5, 0.5)", r, c, v)
+			}
+		}
+	}
+}
+
+func TestNewWithSeed_DeterministicWithSameSeed(t *testing.T) {
+	m1 := NewWithSeed(4, 5, 42)
+	m2 := NewWithSeed(4, 5, 42)
+
+	for r := 0; r < 4; r++ {
+		for c := 0; c < 5; c++ {
+			if m1.At(r, c) != m2.At(r, c) {
+				t.Errorf("deterministic mismatch at (%d,%d): %v vs %v", r, c, m1.At(r, c), m2.At(r, c))
+			}
+		}
+	}
+}
+
+func TestNewWithSeed_DifferentSeedsProduceDifferentMatrices(t *testing.T) {
+	m1 := NewWithSeed(4, 5, 42)
+	m2 := NewWithSeed(4, 5, 99)
+
+	different := false
+	for r := 0; r < 4; r++ {
+		for c := 0; c < 5; c++ {
+			if m1.At(r, c) != m2.At(r, c) {
+				different = true
+				break
+			}
+		}
+		if different {
+			break
+		}
+	}
+
+	if !different {
+		t.Errorf("expected different seeds to produce different matrices")
+	}
+}
+
+func TestNewWithSeed_ValuesInRange(t *testing.T) {
+	m := NewWithSeed(50, 50, 1)
+
+	for r := 0; r < m.Rows; r++ {
+		for c := 0; c < m.Cols; c++ {
+			v := m.At(r, c)
+			if v <= -0.5 || v >= 0.5 {
+				t.Errorf("value at (%d,%d) = %v, expected in (-0.5, 0.5)", r, c, v)
+			}
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/leandronsp/dipirona/issues/5

### Background

Implements the feedforward MLP with backpropagation training, the core missing piece that turns dipirona from a collection of math primitives into a usable neural network library. The network can now learn from data: forward pass, MSE loss computation, gradient backpropagation, and weight updates all work end to end. An XOR convergence integration test proves the full pipeline.

### Key Decisions

1. **Layer caches input and pre-activation (z) in Forward**: Backward needs both the original input and the raw matmul result before activation. Caching them during Forward avoids recomputation and keeps the Backward API clean.
2. **Batch-aware Train**: `Train(input, target Matrix)` supports both single-sample and multi-row inputs. The XOR integration test uses batch training (all 4 patterns per epoch) for stable convergence on the XOR problem.
3. **Gradient computed before weight update**: Backward propagates the gradient through the old weights, then updates. This ensures correct backprop through unchanged topology.
4. **XOR with lr=5.0**: The 2-hidden-neuron architecture converges reliably on XOR within 10000 epochs using batch training and learning rate 5.0. Random weight initialization via `NewWithSeed` makes the test deterministic.
5. **Convenience methods on Matrix**: Added `Subtract` and `Scale` wrapping `Zip`/`Map`, used extensively in backprop math.
6. **100% test coverage** across all packages (calc, model, layer, random, network, validate).